### PR TITLE
fix: update GoReleaser config for webpack bundling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ node_modules/
 # Build output
 out/
 dist/
+build/
 
 # VS Code specific files
 *.vsix

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,8 +1,9 @@
 version: 2
+dist: build
 before:
   hooks:
     - npm install
-    - npm run compile
+    - npm run package
     - npx vsce package --out vor-stream-{{ .Version }}.vsix
 
 builds:


### PR DESCRIPTION
## Summary
- Fixed GoReleaser configuration to work with webpack bundling
- Resolved directory conflicts that prevented releases

## Changes
- **GoReleaser**: Updated to use `npm run package` (webpack) instead of `npm run compile`
- **Directory**: Set GoReleaser dist to `build/` to avoid conflicts with webpack's `dist/` 
- **Gitignore**: Added `build/` directory for GoReleaser artifacts

## Test plan
- [x] Verified `goreleaser release --snapshot --clean` runs successfully
- [x] Confirmed webpack bundling works with GoReleaser pipeline
- [x] No directory conflicts between webpack and GoReleaser

This ensures the release process works properly with the new webpack bundling system introduced in #8.

🤖 Generated with [Claude Code](https://claude.ai/code)